### PR TITLE
fix: close jwt source on loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func (s *SpiffeJWT) fetchJWTSVID() (*jwtsvid.SVID, error) {
 		return nil, fmt.Errorf("failed to create JWT source: %w", err)
 	}
 	logrus.Info("JWT source created")
+	defer jwtSource.Close()
 
 	// Fetch validated JWT SVID
 	jwt, err := jwtSource.FetchJWTSVID(ctx, jwtsvid.Params{Audience: s.JWTAudience})


### PR DESCRIPTION
When using daemon mode, long running pods accumulate connections, and might end up being killed. 

<img width="1494" alt="Screenshot 2025-04-05 at 2 56 12 PM" src="https://github.com/user-attachments/assets/0f9d7e65-4a60-4f01-b8a3-343daeb78bbe" />

