### PR TITLE
add timeout when connecting to SPIRE

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,8 @@ func (s *SpiffeJWT) fetchAndWriteJWTSVID() (*jwtsvid.SVID, error) {
 
 // fetchJWTSVID fetches a JWT SVID from the SPIFFE agent
 func (s *SpiffeJWT) fetchJWTSVID() (*jwtsvid.SVID, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	// Create connection to SPIFFE agent
 	jwtSource, err := workloadapi.NewJWTSource(ctx,


### PR DESCRIPTION
We noticed that very occasionally spiffe-jwt would just hang before even successfully connecting to the SPIRE server. This will hopefully cause it to error (and ultimately panic) after 10 seconds of no response. 